### PR TITLE
Saco la logica de los request con Retrofit de la UI

### DIFF
--- a/app/src/main/java/com/example/chotuve_android_client/services/PingService.kt
+++ b/app/src/main/java/com/example/chotuve_android_client/services/PingService.kt
@@ -1,0 +1,27 @@
+package com.example.chotuve_android_client.services
+
+import android.util.Log
+import com.example.chotuve_android_client.apis.DefaultApi
+import com.example.chotuve_android_client.models.PingResponse
+import com.example.chotuve_android_client.tools.RetrofitObject
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.schedulers.Schedulers
+import retrofit2.Retrofit
+
+class PingService {
+
+    private val retrofit : Retrofit = RetrofitObject.retrofit
+    private val pingService = retrofit.create(DefaultApi::class.java)
+
+    fun pingServer(
+        disposable: CompositeDisposable?,
+        onSuccess: (serverStatus: PingResponse?) -> Unit,
+        onError: (throwable: Throwable) -> Unit
+    ) {
+        disposable?.add(pingService.apiPingGet()
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribeOn(Schedulers.io())
+            .subscribe(onSuccess, onError))
+    }
+}

--- a/app/src/main/java/com/example/chotuve_android_client/tools/RetrofitObject.kt
+++ b/app/src/main/java/com/example/chotuve_android_client/tools/RetrofitObject.kt
@@ -1,0 +1,15 @@
+package com.example.chotuve_android_client.tools
+
+import retrofit2.Retrofit
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+object RetrofitObject {
+
+    val retrofit: Retrofit = Retrofit.Builder()
+        //TODO sacar URL hardcoded (ver si se puede pasar a gradle profiles)
+        .baseUrl("https://chotuve-app-server-production.herokuapp.com/")
+        .addConverterFactory(MoshiConverterFactory.create())
+        .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+        .build()
+}

--- a/app/src/main/java/com/example/chotuve_android_client/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/chotuve_android_client/ui/home/HomeFragment.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import com.example.chotuve_android_client.R
 import com.example.chotuve_android_client.apis.DefaultApi
+import com.example.chotuve_android_client.services.PingService
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
@@ -52,27 +53,41 @@ class HomeFragment : Fragment() {
 
         view.findViewById<Button>(R.id.ping_button).setOnClickListener {
             val homeTextView = view.findViewById<TextView>(R.id.text_home)
-            val retrofit = Retrofit.Builder()
-                    //TODO sacar URL hardcoded (ver si se puede pasar a gradle profiles)
-                .baseUrl("https://chotuve-app-server-production.herokuapp.com/")
-                .addConverterFactory(MoshiConverterFactory.create())
-                .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
-                .build()
-            val pingService = retrofit.create(DefaultApi::class.java)
-            myCompositeDisposable?.add(pingService.apiPingGet()
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribeOn(Schedulers.io())
-                .subscribe({
-                        serverStatus -> homeTextView.text = "App Server Status:  ${serverStatus.AppServer}\n" +
-                                "Media Server Status: ${serverStatus.MediaServer}\n" +
-                                "Auth Server Status: ${serverStatus.AuthServer}" ;
-                        Log.i("App server", "App Server Status:  ${serverStatus.AppServer}");
-                        Log.i("Media Server", "Media Server Status: ${serverStatus.MediaServer}");
-                        Log.i("Auth Server", "Auth Server Status: ${serverStatus.AuthServer}");
+//            val retrofit = Retrofit.Builder()
+//                    //TODO sacar URL hardcoded (ver si se puede pasar a gradle profiles)
+//                .baseUrl("https://chotuve-app-server-production.herokuapp.com/")
+//                .addConverterFactory(MoshiConverterFactory.create())
+//                .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+//                .build()
+//            val pingService = retrofit.create(DefaultApi::class.java)
+//            myCompositeDisposable?.add(pingService.apiPingGet()
+//                .observeOn(AndroidSchedulers.mainThread())
+//                .subscribeOn(Schedulers.io())
+//                .subscribe({
+//                        serverStatus -> homeTextView.text = "App Server Status:  ${serverStatus.AppServer}\n" +
+//                                "Media Server Status: ${serverStatus.MediaServer}\n" +
+//                                "Auth Server Status: ${serverStatus.AuthServer}" ;
+//                        Log.i("App server", "App Server Status:  ${serverStatus.AppServer}");
+//                        Log.i("Media Server", "Media Server Status: ${serverStatus.MediaServer}");
+//                        Log.i("Auth Server", "Auth Server Status: ${serverStatus.AuthServer}");
+//
+//                    },
+//                    Throwable::printStackTrace  // TODO manejar error
+//                ))
+            val pingService = PingService()
+            pingService.pingServer(
+                myCompositeDisposable,
+                {
+                    serverStatus -> homeTextView.text = "App Server Status:  ${serverStatus?.AppServer}\n" +
+                            "Media Server Status: ${serverStatus?.MediaServer}\n" +
+                            "Auth Server Status: ${serverStatus?.AuthServer}" ;
+                    Log.i("App server", "App Server Status:  ${serverStatus?.AppServer}");
+                    Log.i("Media Server", "Media Server Status: ${serverStatus?.MediaServer}");
+                    Log.i("Auth Server", "Auth Server Status: ${serverStatus?.AuthServer}");
 
-                    },
-                    Throwable::printStackTrace  // TODO manejar error
-                ))
+                },
+                Throwable::printStackTrace  // TODO manejar error
+            )
 //                .doAfterSuccess { pet ->
 //                    homeTextView.text = "First pet name is " + pet.name
 //                }


### PR DESCRIPTION
La consulta al AppServer con el ping que estaba en HomeFragment ahora está dividida en dos módulos:
* Se crea un singleton RetrofitObject que genera una única instancia de Retrofit reusable en todos los requests.
* Se crea un paquete Service que por ahora tiene solamente el PingService. Recibe por parámetro el disposable (que dejé por las dudas en la vista porque no entiendo bien su ciclo de vida) y los callbacks que tiene que ejecutar si salió OK o tuvo error.

Dejé comentado el código original por si había que volver atrás el cambio rápido. Cuando se agreguen más tipos de requests y tengamos confianza de que funciona, este código comentado se puede borrar.